### PR TITLE
fix ThingWorx 10.1 Monaco editor compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@placatus/twx-monaco-editor",
     "packageName": "MonacoScriptEditor",
-    "version": "1.26.1",
+    "version": "1.26.2",
     "description": "Replaces the out of the box code editor in the old composer with a new one.",
     "author": "placatus@iqnox.com",
     "minimumThingWorxVersion": "6.0.0",
@@ -76,5 +76,6 @@
         "commitizen": {
             "path": "./node_modules/cz-conventional-changelog"
         }
-    }
+    },
+    "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/src/editors/basicCodeEditor.ts
+++ b/src/editors/basicCodeEditor.ts
@@ -335,20 +335,26 @@ export class MonacoCodeEditor {
             return str.replace(/\/$/, "");
         }
 
+        function stripUrlCredentials(str: string) {
+            try {
+                const url = new URL(str, window.location.origin);
+                url.username = "";
+                url.password = "";
+                return url.toString();
+            } catch (e) {
+                return str;
+            }
+        }
+
+        const publicPath = stripUrlCredentials(typeof __webpack_public_path__ === "string" ? __webpack_public_path__ : "");
+
         (window as any).MonacoEnvironment = {
             globalAPI: true,
             getWorkerUrl: function (moduleId, label) {
-                const pathPrefix = typeof __webpack_public_path__ === "string" ? __webpack_public_path__ : "";
+                const pathPrefix = publicPath;
                 const result = (pathPrefix ? stripTrailingSlash(pathPrefix) + "/" : "") + workerPaths[label];
                 if (/^((http:)|(https:)|(file:)|(\/\/))/.test(result)) {
-                    const currentUrl = String(window.location);
-                    const currentOrigin = currentUrl.substr(
-                        0,
-                        currentUrl.length -
-                            window.location.hash.length -
-                            window.location.search.length -
-                            window.location.pathname.length
-                    );
+                    const currentOrigin = window.location.origin;
                     if (result.substring(0, currentOrigin.length) !== currentOrigin) {
                         const js = "/*" + label + '*/importScripts("' + result + '");';
                         const blob = new Blob([js], { type: "application/javascript" });
@@ -375,10 +381,10 @@ export class MonacoCodeEditor {
 
         // Customize the typescript worker to add the methods needed by the script editor as well as CodeHost
         monaco.languages.typescript.typescriptDefaults.setWorkerOptions({
-            customWorkerPath: __webpack_public_path__ + "tsCustomWorker.bundle.js",
+            customWorkerPath: publicPath + "tsCustomWorker.bundle.js",
         });
         monaco.languages.typescript.javascriptDefaults.setWorkerOptions({
-            customWorkerPath: __webpack_public_path__ + "tsCustomWorker.bundle.js",
+            customWorkerPath: publicPath + "tsCustomWorker.bundle.js",
         });
     }
 

--- a/src/newComposerMonacoEditor.ts
+++ b/src/newComposerMonacoEditor.ts
@@ -13,27 +13,6 @@ enum EditorType {
     GENERIC_EDITOR = "generic-editor"
 }
 
-const CODEMIRROR_COMPAT_MODULES = [
-    "codemirror",
-    "codemirror/mode/css/css",
-    "codemirror/mode/javascript/javascript",
-    "codemirror/mode/xml/xml",
-    "codemirror/mode/sql/sql",
-    "codemirror/addon/selection/mark-selection",
-    "codemirror/addon/search/search",
-    "codemirror/addon/search/searchcursor",
-    "codemirror/addon/dialog/dialog",
-    "codemirror/addon/edit/matchbrackets",
-    "codemirror/addon/search/match-highlighter",
-    "codemirror/addon/hint/show-hint",
-    "codemirror/addon/hint/javascript-hint",
-    "codemirror/addon/fold/foldcode",
-    "codemirror/addon/fold/foldgutter",
-    "codemirror/addon/fold/brace-fold",
-    "codemirror/addon/fold/comment-fold",
-    "codemirror/addon/fold/indent-fold",
-];
-
 const CODEMIRROR_GUTTER_MESSAGE_MANAGER =
     "thingworx-ui-platform/features/details/editor/codemirror-gutter-message-manager";
 
@@ -42,46 +21,37 @@ function getAmdContext() {
     return requirejs && requirejs.s && requirejs.s.contexts && requirejs.s.contexts._;
 }
 
-function isAmdModuleKnown(moduleName: string): boolean {
+function getDefinedAmdModule(moduleName: string) {
     const context = getAmdContext();
-    if (!context) {
-        return false;
-    }
-
-    return Boolean(
-        (context.defined && context.defined[moduleName]) ||
-            (context.specified && context.specified[moduleName]) ||
-            (context.registry && context.registry[moduleName])
-    );
+    return context && context.defined ? context.defined[moduleName] : undefined;
 }
 
-function defineAmdModuleIfMissing(moduleName: string, factory: () => any) {
-    if (isAmdModuleKnown(moduleName)) {
-        return;
-    }
-
-    window["define"](moduleName, [], factory);
+function createNoopGutterMessageManager() {
+    return {
+        addByCategory() {},
+        removeByCategory() {},
+        clearByCategory() {},
+        clear() {},
+        add() {},
+        remove() {},
+    };
 }
 
-function installCodeMirrorCompatibilityShim() {
-    CODEMIRROR_COMPAT_MODULES.forEach((moduleName) => {
-        defineAmdModuleIfMissing(moduleName, () => {
-            if (moduleName === "codemirror") {
-                return window["CodeMirror"] || {};
-            }
+function resolveGutterMessageManager(container: any) {
+    const moduleExport = getDefinedAmdModule(CODEMIRROR_GUTTER_MESSAGE_MANAGER);
+    const gutterManagerClass = moduleExport && moduleExport.CodemirrorGutterMessageManager;
+    if (gutterManagerClass) {
+        try {
+            return container.get(gutterManagerClass);
+        } catch (e) {
+            console.warn("Monaco: Failed to resolve CodemirrorGutterMessageManager. Using fallback...", e);
+        }
+    }
 
-            return {};
-        });
-    });
-
-    defineAmdModuleIfMissing(CODEMIRROR_GUTTER_MESSAGE_MANAGER, () => ({
-        CodemirrorGutterMessageManager: class CodemirrorGutterMessageManager {},
-    }));
+    return createNoopGutterMessageManager();
 }
 
 function load() {
-    installCodeMirrorCompatibilityShim();
-
     window["define"](
       "thingworx-ui-platform/features/details/editor/abstract-editor",
       [
@@ -90,8 +60,6 @@ function load() {
         "aurelia-dependency-injection",
         "lodash",
         "jquery",
-        "codemirror",
-        "./codemirror-gutter-message-manager",
         "thingworx-ui-platform/util/common-util",
         "thingworx-ui-platform/util/object-util",
         "thingworx-ui-platform/helpers/loader-helper",
@@ -99,30 +67,12 @@ function load() {
         "thingworx-ui-platform/events/event-helper",
         "thingworx-ui-platform/services/user-service",
         "thingworx-ui-platform/services/entity-service-base",
-        "thingworx-ui-platform/helpers/hotkeys/hotkey-manager",
-        "codemirror/mode/css/css",
-        "codemirror/mode/javascript/javascript",
-        "codemirror/mode/xml/xml",
-        "codemirror/mode/sql/sql",
-        "codemirror/addon/selection/mark-selection",
-        "codemirror/addon/search/search",
-        "codemirror/addon/search/searchcursor",
-        "codemirror/addon/dialog/dialog",
-        "codemirror/addon/edit/matchbrackets",
-        "codemirror/addon/search/match-highlighter",
-        "codemirror/addon/hint/show-hint",
-        "codemirror/addon/hint/javascript-hint",
-        "codemirror/addon/fold/foldcode",
-        "codemirror/addon/fold/foldgutter",
-        "codemirror/addon/fold/brace-fold",
-        "codemirror/addon/fold/comment-fold",
-        "codemirror/addon/fold/indent-fold"
+        "thingworx-ui-platform/helpers/hotkeys/hotkey-manager"
     ],
-    function(exports, I18N, Container, _, $, CodeMirror, CodemirrorGutterMessageManager, CommonUtil, ObjectUtil, LoaderHelper, ChannelNames, EventHelper, u, EntityServiceBase, HotkeyManager) {
+    function(exports, I18N, Container, _, $, CommonUtil, ObjectUtil, LoaderHelper, ChannelNames, EventHelper, u, EntityServiceBase, HotkeyManager) {
         var {UserSessionInfoKeys, UserPreferenceKeys} = u;
         I18N = I18N["I18N"];
         Container = Container["Container"];
-        CodemirrorGutterMessageManager = CodemirrorGutterMessageManager["CodemirrorGutterMessageManager"];
         CommonUtil = CommonUtil["CommonUtil"];
         ObjectUtil = ObjectUtil["ObjectUtil"];
         LoaderHelper = LoaderHelper["LoaderHelper"];
@@ -447,7 +397,7 @@ function load() {
             //== following should be treated as private methods and subject to change without notifiying =====================
             AbstractEditor.prototype._init = function(opts) {
                 let container = Container.instance || new Container();
-                this.gutterMsgManager = container.get(CodemirrorGutterMessageManager);
+                this.gutterMsgManager = resolveGutterMessageManager(container);
                 this.entityService = container.get(EntityServiceBase);
                 this.i18n = container.get(I18N);
                 this._setGuttersOption();

--- a/src/newComposerMonacoEditor.ts
+++ b/src/newComposerMonacoEditor.ts
@@ -13,7 +13,75 @@ enum EditorType {
     GENERIC_EDITOR = "generic-editor"
 }
 
+const CODEMIRROR_COMPAT_MODULES = [
+    "codemirror",
+    "codemirror/mode/css/css",
+    "codemirror/mode/javascript/javascript",
+    "codemirror/mode/xml/xml",
+    "codemirror/mode/sql/sql",
+    "codemirror/addon/selection/mark-selection",
+    "codemirror/addon/search/search",
+    "codemirror/addon/search/searchcursor",
+    "codemirror/addon/dialog/dialog",
+    "codemirror/addon/edit/matchbrackets",
+    "codemirror/addon/search/match-highlighter",
+    "codemirror/addon/hint/show-hint",
+    "codemirror/addon/hint/javascript-hint",
+    "codemirror/addon/fold/foldcode",
+    "codemirror/addon/fold/foldgutter",
+    "codemirror/addon/fold/brace-fold",
+    "codemirror/addon/fold/comment-fold",
+    "codemirror/addon/fold/indent-fold",
+];
+
+const CODEMIRROR_GUTTER_MESSAGE_MANAGER =
+    "thingworx-ui-platform/features/details/editor/codemirror-gutter-message-manager";
+
+function getAmdContext() {
+    const requirejs = window["requirejs"] || window["require"];
+    return requirejs && requirejs.s && requirejs.s.contexts && requirejs.s.contexts._;
+}
+
+function isAmdModuleKnown(moduleName: string): boolean {
+    const context = getAmdContext();
+    if (!context) {
+        return false;
+    }
+
+    return Boolean(
+        (context.defined && context.defined[moduleName]) ||
+            (context.specified && context.specified[moduleName]) ||
+            (context.registry && context.registry[moduleName])
+    );
+}
+
+function defineAmdModuleIfMissing(moduleName: string, factory: () => any) {
+    if (isAmdModuleKnown(moduleName)) {
+        return;
+    }
+
+    window["define"](moduleName, [], factory);
+}
+
+function installCodeMirrorCompatibilityShim() {
+    CODEMIRROR_COMPAT_MODULES.forEach((moduleName) => {
+        defineAmdModuleIfMissing(moduleName, () => {
+            if (moduleName === "codemirror") {
+                return window["CodeMirror"] || {};
+            }
+
+            return {};
+        });
+    });
+
+    defineAmdModuleIfMissing(CODEMIRROR_GUTTER_MESSAGE_MANAGER, () => ({
+        CodemirrorGutterMessageManager: class CodemirrorGutterMessageManager {},
+    }));
+}
+
 function load() {
+    installCodeMirrorCompatibilityShim();
+
     window["define"](
       "thingworx-ui-platform/features/details/editor/abstract-editor",
       [
@@ -450,7 +518,12 @@ function load() {
                     console.log('Monaco is starting initialization with options...', );
                 }
 
-                if (!this.cmTextarea || !this.element) {
+                if (!this.element) {
+                    return;
+                }
+
+                const container = this.cmTextarea ? this.cmTextarea.parentElement : this.element.querySelector(".script-control");
+                if (!container) {
                     return;
                 }
 
@@ -509,7 +582,6 @@ function load() {
                     }
                 }
 
-                let container = this.cmTextarea.parentElement;
                 let modelName;
                 if (this.editorType == EditorType.SERVICE_EDITOR || this.editorType == EditorType.SUBSCRIPTION_EDITOR) {
                     if(currentEditedModel) {
@@ -520,8 +592,12 @@ function load() {
                 } else {
                     modelName =  Math.random().toString(36).substring(7);
                 }
-                // Hide the existing text area. Don't completely wipe it because it gets reused in the subscription editor
-                this.cmTextarea.style.display = 'none';
+                // Hide the legacy textarea when present. ThingWorx 10.1 uses an empty .script-control mount instead.
+                if (this.cmTextarea) {
+                    this.cmTextarea.style.display = 'none';
+                } else {
+                    container.innerHTML = "";
+                }
                 // Create a new editor, using the class inferred from the language id
                 this.codeMirror = new editorClass(
                     container,

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -5,11 +5,15 @@ import { DataShape, FieldDefinition } from './types';
 const MIME_APPLICATION_JSON = "application/json";
 const MIME_TEXT_XML = "text/xml";
 
+function platformUrl(path: string): string {
+    return `${window.location.origin}${path}`;
+}
+
 /**
  * Gets the metadata of all the datashapes in the system. Uses the export of all datashapes
  */
 export async function getDataShapeDefinitions(): Promise<DataShape[]> {
-    const response = await fetch(`/Thingworx/Exporter/DataShapes?universal=true`, {
+    const response = await fetch(platformUrl(`/Thingworx/Exporter/DataShapes?universal=true`), {
         method: 'GET',
         headers: {
             'Accept': MIME_TEXT_XML
@@ -41,7 +45,7 @@ export async function getDataShapeDefinitions(): Promise<DataShape[]> {
  * @param  {string} searchTerm The entity to search for. Only the prefix can be specified.
  */
 export async function spotlightSearch(entityType, searchTerm): Promise<any> {
-    const response = await fetch(`/Thingworx/Resources/SearchFunctions/Services/SpotlightSearch`, {
+    const response = await fetch(platformUrl(`/Thingworx/Resources/SearchFunctions/Services/SpotlightSearch`), {
         method: 'POST',
         body: JSON.stringify({
             searchExpression: searchTerm + "*",
@@ -95,7 +99,7 @@ export function sanitizeEntityName(entityName: string): string {
 }
 
 export async function getScriptFunctionLibraries(): Promise<any[]> {
-    const response = await fetch(`/Thingworx/ScriptFunctionLibraries`, {
+    const response = await fetch(platformUrl(`/Thingworx/ScriptFunctionLibraries`), {
         headers: {
             'Accept': MIME_APPLICATION_JSON
         }
@@ -103,7 +107,7 @@ export async function getScriptFunctionLibraries(): Promise<any[]> {
     const libraries = await response.json();
     const result = [];
     for (const scriptFunction of libraries.rows) {
-        const scriptResponse = await fetch(`/Thingworx/ScriptFunctionLibraries/${scriptFunction.name}/FunctionDefinitions`, {
+        const scriptResponse = await fetch(platformUrl(`/Thingworx/ScriptFunctionLibraries/${scriptFunction.name}/FunctionDefinitions`), {
             headers: {
                 'Accept': MIME_APPLICATION_JSON
             }
@@ -118,7 +122,7 @@ export function isGenericService(serviceDefinition: { sourceName: string, source
 }
 
 export async function getEntityMetadata(entityType: string, entityName: string): Promise<any> {
-    const response = await fetch(`/Thingworx/${entityType}/${encodeURIComponent(entityName)}/Metadata`, {
+    const response = await fetch(platformUrl(`/Thingworx/${entityType}/${encodeURIComponent(entityName)}/Metadata`), {
         headers: {
             'Accept': MIME_APPLICATION_JSON
         }
@@ -127,7 +131,7 @@ export async function getEntityMetadata(entityType: string, entityName: string):
 }
 
 export async function getEntityInstancesMetadata(entityType: string, entityName: string): Promise<any> {
-    const response = await fetch(`/Thingworx/${entityType}/${encodeURIComponent(entityName)}/InstanceMetadata`, {
+    const response = await fetch(platformUrl(`/Thingworx/${entityType}/${encodeURIComponent(entityName)}/InstanceMetadata`), {
         headers: {
             'Accept': MIME_APPLICATION_JSON
         }
@@ -136,7 +140,7 @@ export async function getEntityInstancesMetadata(entityType: string, entityName:
 }
 
 export async function getThingPropertyValues(entityName: string): Promise<any> {
-    const response = await fetch(`/Thingworx/Things/${encodeURIComponent(entityName)}/Properties`, {
+    const response = await fetch(platformUrl(`/Thingworx/Things/${encodeURIComponent(entityName)}/Properties`), {
         headers: {
             'Accept': MIME_APPLICATION_JSON
         }


### PR DESCRIPTION
## Intent

- Add thingworx 10.1 compatibility

## Implementation

- In TWX 10.1, the gutter manager changed meaning that we cannot import it.
- Just have a noop, in order to also allow compatibility with older versions